### PR TITLE
Bug fix: Fixed calendar.events.list API call error (incorrect argument)

### DIFF
--- a/main.js
+++ b/main.js
@@ -184,7 +184,7 @@ function syncFromGCal(c_name, fullSync, ignored_eIds) {
         e.message === "Sync token is no longer valid, a full sync is required." || e.message === "API call to calendar.events.list failed with error: Sync token is no longer valid, a full sync is required."
       ) {
         properties.deleteProperty("syncToken");
-        syncFromGCal(CALENDAR_IDS[c_name], true, ignored_eIds);
+        syncFromGCal(c_name, true, ignored_eIds);
         return;
       } else {
         throw new Error(e.message);


### PR DESCRIPTION
- Resolved an error that occurred when calling the calendar.events.list API.
- The API call was failing due to previously incorrect arguments.
- The arguments have been corrected and the API call now functions successfully.
- Testing has been conducted to verify that the API call is working as expected.